### PR TITLE
Feature/prev next post links

### DIFF
--- a/src/app/(public)/post/[id]/page.tsx
+++ b/src/app/(public)/post/[id]/page.tsx
@@ -1,10 +1,16 @@
-import { notFound } from 'next/navigation';
 import LatestPostList from '@/components/LatestPostList';
 import PostDetail from '@/components/PostDetail';
 import PostCard from '@/components/PostCard';
 import TagList from '@/components/TagList';
-import { getLatestPosts, getPost } from '@/lib/post';
+import {
+  getLatestPosts,
+  getNextPost,
+  getPost,
+  getPreviousPost,
+} from '@/lib/post';
 import { getAllTags, getTagsByPostIdAndRelatedPosts } from '@/lib/tag';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
 type Params = {
   params: Promise<{ id: number }>;
@@ -35,12 +41,39 @@ const PostPage = async ({ params }: Params) => {
 
   console.log(relatedPosts);
 
+  const previousPostId = await getPreviousPost(post.updatedAt);
+  const nextPostId = await getNextPost(post.updatedAt);
+
   return (
     <div className="py-7 md:mx-auto md:container px-4 lg:px-40 ">
       <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr] gap-12">
         <div className="flex flex-col gap-12">
           <PostDetail post={post} />
-          <div className="border rounded p-6 shadow-md">
+          <div className="flex justify-between items-center mt-6 border-t pt-6 text-sm text-white">
+            {previousPostId ? (
+              <Link
+                href={`/post/${previousPostId}`}
+                className="px-4 py-2 border bg-gray-900 hover:bg-gray-300 rounded-md"
+              >
+                ◀ 前の記事
+              </Link>
+            ) : (
+              <span />
+            )}
+
+            {nextPostId ? (
+              <Link
+                href={`/post/${nextPostId}`}
+                className="px-4 py-2 border bg-gray-900 hover:bg-gray-300 rounded-md"
+              >
+                次の記事 ▶
+              </Link>
+            ) : (
+              <span />
+            )}
+          </div>
+
+          <div className="border rounded p-6 bg-white shadow-md">
             <h2 className="text-lg font-bold border-b pb-2 mb-6">関連記事</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {relatedPosts.map(post => (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -122,7 +122,7 @@
   }
 }
 
-.btc:hover {
+.btn:hover {
   background-color: #4f46e5;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,14 @@
+import { Metadata } from 'next';
 import './globals.css';
+
+export const metadata: Metadata = {
+  title: {
+    default: 'My Blog',
+    template: '%s | My Blog',
+  },
+  description:
+    'これは私の個人ブログです。Web開発、日記、技術記事などを発信しています。',
+};
 
 export default function RootLayout({
   children,

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -38,7 +38,7 @@ const PostCard = ({ post }: PostProp) => {
       <div className="flex flex-wrap gap-2 px-6 mt-auto">
         {post.tags.map(tag => (
           <Link key={tag.id} href={`/tags/${tag.name}`}>
-            <span className="text-xs px-2.5 py-0.5 font-medium text-white bg-gray-800 transition hover:bg-gray-700 hover:shadow-sm hover:scale-[1.03] rounded-full">
+            <span className="text-xs px-2.5 py-0.5 font-medium text-white bg-gray-800 transition hover:bg-gray-300 hover:shadow-sm hover:scale-[1.03] rounded-full">
               {tag.name}
             </span>
           </Link>

--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -9,8 +9,10 @@ import Image from 'next/image';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { getMarkdownTextServer } from '@/lib/markdown';
+import { Tag } from '@/types/post';
+import Link from 'next/link';
 
-type PostProp = {
+type Prop = {
   post: {
     id: number;
     title: string;
@@ -19,10 +21,11 @@ type PostProp = {
     coverImageUrl: string;
     createdAt: Date;
     updatedAt: Date;
+    tags: Tag[];
   };
 };
 
-const PostDetail = ({ post }: PostProp) => (
+const PostDetail = ({ post }: Prop) => (
   <Card className="w-full md:max-w-3xl rounded pt-0">
     <div className="relative w-full h-80 lg:h-100">
       <Image
@@ -49,6 +52,15 @@ const PostDetail = ({ post }: PostProp) => (
           className="markdown-body prose max-w-none w-full py-4"
           dangerouslySetInnerHTML={getMarkdownTextServer(post.content)}
         />
+        <div className="flex flex-wrap gap-4 px-2 mt-10">
+          {post.tags.map(tag => (
+            <Link key={tag.id} href={`/tags/${tag.name}`}>
+              <span className="text-sm px-5 py-1 font-medium text-white bg-gray-800 transition hover:bg-gray-300 hover:shadow-sm hover:scale-[1.03] rounded-full">
+                {tag.name}
+              </span>
+            </Link>
+          ))}
+        </div>
       </CardContent>
     </div>
   </Card>

--- a/src/components/TagList.tsx
+++ b/src/components/TagList.tsx
@@ -18,7 +18,7 @@ const TagList = ({ tags }: Prop) => (
         <Link
           href={`/tags/${tag.name}`}
           key={tag.id}
-          className="px-3 py-1 text-sm font-medium text-gray-700 bg-gray-100 rounded-full hover:text-white btc"
+          className="px-3 py-1 text-sm font-medium text-gray-700 bg-gray-100 rounded-full hover:text-white btn"
         >
           {tag.name}
         </Link>

--- a/src/lib/post.ts
+++ b/src/lib/post.ts
@@ -17,6 +17,38 @@ export const getPublishedPosts = async () => {
   });
 };
 
+export const getPreviousPost = async (updatedAt: Date) => {
+  const previousPost = await prisma.post.findFirst({
+    where: {
+      published: true,
+      updatedAt: {
+        lt: updatedAt,
+      },
+    },
+    orderBy: {
+      updatedAt: 'desc',
+    },
+  });
+
+  return previousPost?.id;
+};
+
+export const getNextPost = async (updatedAt: Date) => {
+  const nextPost = await prisma.post.findFirst({
+    where: {
+      published: true,
+      updatedAt: {
+        gt: updatedAt,
+      },
+    },
+    orderBy: {
+      updatedAt: 'asc',
+    },
+  });
+
+  return nextPost?.id;
+};
+
 export const getAllPosts = async () => {
   return await prisma.post.findMany({
     orderBy: {

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,4 +1,4 @@
-type Tag = {
+export type Tag = {
   id: number;
   name: string;
 };


### PR DESCRIPTION
## Summary

This PR adds navigation links to the previous and next blog posts on the post detail page.

## Changes

- Added `getPreviousPost` and `getNextPost` functions using `updatedAt`
- Displayed navigation buttons at the bottom of the post detail view
- Improved user navigation between blog entries
