### PR TITLE
Feature/comment reply admin by email

### DIFF
--- a/prisma/migrations/20250617055543_add_comment_reply/migration.sql
+++ b/prisma/migrations/20250617055543_add_comment_reply/migration.sql
@@ -1,0 +1,18 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Comment" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "postId" INTEGER NOT NULL,
+    "author" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "parentId" INTEGER,
+    CONSTRAINT "Comment_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Comment_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Comment" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Comment" ("author", "content", "createdAt", "id", "postId") SELECT "author", "content", "createdAt", "id", "postId" FROM "Comment";
+DROP TABLE "Comment";
+ALTER TABLE "new_Comment" RENAME TO "Comment";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20250617104902_add_author_id_to_comment/migration.sql
+++ b/prisma/migrations/20250617104902_add_author_id_to_comment/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN "authorEmail" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,10 +32,14 @@ model Tag {
 }
 
 model Comment {
-  id             Int      @id @default(autoincrement())
+  id             Int       @id @default(autoincrement())
   postId         Int
-  post           Post     @relation(fields: [postId], references: [id])
+  post           Post      @relation(fields: [postId], references: [id])
   author         String
   content        String
   createdAt      DateTime  @default(now())
+  authorEmail    String?
+  parentId       Int?
+  parent         Comment?  @relation("CommentToParent", fields: [parentId], references: [id])
+  replies        Comment[] @relation("CommentToParent")
 }

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -1,0 +1,67 @@
+import { Comment } from '@/types/post';
+import { formatDistanceToNow } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import { User } from 'lucide-react';
+
+type Props = {
+  comment: Comment;
+  allComments: Comment[];
+  onReplyClick: (commentId: number) => void;
+  user?: {
+    id?: string;
+    name?: string | null;
+    email?: string | null;
+  };
+};
+
+const CommentThread = ({ comment, allComments, onReplyClick, user }: Props) => {
+  const replies = allComments.filter(c => c.parentId === comment.id);
+
+  const adminEmail = process.env.NEXT_PUBLIC_ADMIN_EMAIL;
+  const isMyComment = adminEmail === comment.authorEmail;
+
+  return (
+    <div className="ml-4 mt-4 border-l border-gray-200 pl-4">
+      <div className="flex items-center gap-2 text-sm text-gray-700 mb-1">
+        <User
+          className={`w-8 h-8 text-white ${
+            isMyComment ? 'bg-blue-500' : 'bg-gray-500'
+          }   rounded-full`}
+        />
+        <span className="font-medium">{comment.author}</span>
+        {isMyComment && (
+          <span className="bg-blue-100 p-1 rounded-full text-blue-600">
+            管理人
+          </span>
+        )}
+        <span className="text-xs text-gray-400 ml-2">
+          {formatDistanceToNow(new Date(comment.createdAt), {
+            addSuffix: true,
+            locale: ja,
+          })}
+        </span>
+      </div>
+      <div className="flex gap-6">
+        <p className="text-sm text-gray-800 mt-3">{comment.content}</p>
+        <button
+          onClick={() => onReplyClick(comment.id)}
+          className="text-sm text-blue-500 hover:underline cursor-pointer mt-2"
+        >
+          返信する
+        </button>
+      </div>
+
+      {replies.map(reply => (
+        <CommentThread
+          key={reply.id}
+          comment={reply}
+          allComments={allComments}
+          onReplyClick={onReplyClick}
+          user={user}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CommentThread;

--- a/src/lib/post.ts
+++ b/src/lib/post.ts
@@ -65,7 +65,17 @@ export const getPublishedPost = async (postId: number) => {
     },
     include: {
       tags: true,
-      comments: true,
+      comments: {
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          author: true,
+          content: true,
+          createdAt: true,
+          parentId: true,
+          authorEmail: true,
+        },
+      },
     },
   });
 };

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -19,4 +19,6 @@ export type Comment = {
   author: string;
   content: string;
   createdAt: Date;
+  parentId?: number | null;
+  authorEmail?: string | null;
 };


### PR DESCRIPTION
## Summary

This PR introduces a nested comment reply feature and author email tracking for identifying admin comments. Logged-in users will have their email address attached to their comments. Anonymous users will receive a fallback email (`anonymous@unknown.com`).

## Changes

- Added `parentId` and `replies` fields to the `Comment` model for nested replies
- Updated server logic to determine if a comment is a reply based on the presence of `parentId`
- Stored `authorEmail` for each comment
- Used session email if the user is logged in, otherwise assigned a fallback anonymous email
- Updated UI to display nested comment threads
- Enabled visual distinction for admin comments using email matching

## Admin Identification Logic

Comments with an `authorEmail` matching the admin's (e.g. `admin@example.com`) will be rendered as "admin comments" and can be styled differently.
