### PR TITLE
chore: add postinstall script to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.10.1",


### PR DESCRIPTION
Added a `postinstall` script in `package.json` to automatically run `prisma generate` after dependencies are installed.