### PR TITLE
feat(post): implement SSG with generateStaticParams and ISR

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -4,7 +4,6 @@ import { getLatestPosts, getPublishedPosts, searchPosts } from '@/lib/db/post';
 import { getAllTags } from '@/lib/db/tag';
 import { POSTS_PER_PAGE } from '@/lib/constant';
 import Link from 'next/link';
-
 import NotFound from './post/[slug]/not-found';
 import SearchBox from '@/components/ui/SearchBox';
 import LatestPostList from '@/components/post/LatestPostList';

--- a/src/app/(public)/post/[slug]/page.tsx
+++ b/src/app/(public)/post/[slug]/page.tsx
@@ -1,16 +1,14 @@
-export const dynamic = 'force-dynamic';
-
 import PostDetail from '@/components/post/PostDetail';
 import {
   getLatestPosts,
   getNextPost,
   getPublishedPost,
   getPreviousPost,
+  getPublishedPosts,
 } from '@/lib/db/post';
 import { getAllTags, getTagsByPostIdAndRelatedPosts } from '@/lib/db/tag';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-
 import { Metadata } from 'next';
 import ShareButtons from '@/components/ui/ShareButtons';
 import PostCard from '@/components/post/PostCard';
@@ -56,6 +54,13 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
       images: [`${baseUrl}${post.coverImageUrl}`],
     },
   };
+}
+
+export const revalidate = 60;
+
+export async function generateStaticParams() {
+  const posts = await getPublishedPosts();
+  return posts.map(post => ({ slug: post.slug }));
 }
 
 const PostPage = async ({ params }: Params) => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -17,9 +17,6 @@ export const { auth, signIn, signOut, handlers } = NextAuth({
         const adminEmail = process.env.ADMIN_EMAIL;
         const adminPasswordHash = process.env.ADMIN_PASSWORD_HASH;
 
-        console.log('ADMIN_EMAIL:', process.env.ADMIN_EMAIL);
-        console.log('ADMIN_PASSWORD_HASH:', process.env.ADMIN_PASSWORD_HASH);
-
         if (!adminEmail || !adminPasswordHash) {
           console.error('管理者アカウント情報が設定されていません');
           return null;
@@ -38,6 +35,7 @@ export const { auth, signIn, signOut, handlers } = NextAuth({
         const { email, password } = parsedCredentials.data;
 
         if (email !== adminEmail) {
+          console.log('メアドが違います', email);
           return null;
         }
 
@@ -53,6 +51,7 @@ export const { auth, signIn, signOut, handlers } = NextAuth({
             name: 'shuto',
           };
         } else {
+          console.log('パスワード違います', password);
           return null;
         }
       },

--- a/src/lib/actions/authenticate.ts
+++ b/src/lib/actions/authenticate.ts
@@ -11,6 +11,9 @@ export const authenticate = async (
   const email = formData.get('email');
   const password = formData.get('password');
 
+  console.log('メアド', email);
+  console.log('パスワード', password);
+
   try {
     await signIn('credentials', {
       email: email,


### PR DESCRIPTION
This PR enables static generation (SSG) for individual post pages (`/post/[slug]`) using `generateStaticParams`. It also introduces `revalidate` for incremental static regeneration (ISR).