### PR TITLE
Remove use action state in comments

### DIFF
--- a/src/app/(admin)/dashboard/comment/page.tsx
+++ b/src/app/(admin)/dashboard/comment/page.tsx
@@ -1,5 +1,3 @@
-export const dynamic = 'force-dynamic';
-
 import DeleteCommentDialog from '@/components/admin/DeleteCommentDialog';
 import DashboardNav from '@/components/dashboard/DashboardNav';
 import { getComments } from '@/lib/db/comment';

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,5 +1,3 @@
-export const dynamic = 'force-dynamic';
-
 const DashBoardLayout = ({ children }: { children: React.ReactNode }) => {
   return <div className="mt-2">{children}</div>;
 };

--- a/src/app/(public)/tags/[id]/[page]/page.tsx
+++ b/src/app/(public)/tags/[id]/[page]/page.tsx
@@ -11,7 +11,7 @@ type Params = {
   params: Promise<{ page: number; id: string }>;
 };
 
-export const dynamic = 'force-static';
+export const revalidate = 60;
 
 export async function generateStaticParams() {
   const tags = await getAllTags();

--- a/src/app/(public)/tags/[id]/page.tsx
+++ b/src/app/(public)/tags/[id]/page.tsx
@@ -11,7 +11,7 @@ type Params = {
   params: Promise<{ id: string }>;
 };
 
-export const dynamic = 'force-static';
+export const revalidate = 60;
 
 export async function generateStaticParams() {
   const tags = await getAllTags();

--- a/src/app/(public)/tags/page.tsx
+++ b/src/app/(public)/tags/page.tsx
@@ -5,7 +5,7 @@ import { getAllTags } from '@/lib/db/tag';
 import { Tag } from 'lucide-react';
 import Link from 'next/link';
 
-export const dynamic = 'force-static';
+export const revalidate = 60;
 
 const TagsPage = async () => {
   const tags = await getAllTags();

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,0 +1,38 @@
+import { auth } from '@/auth';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/db/prisma';
+
+export async function POST(req: Request) {
+  const formData = await req.json();
+  const session = await auth();
+
+  const commentSchema = z.object({
+    author: z.string().min(1, '名前は必須です'),
+    content: z.string().min(5, 'コメントは5文字以上で入力して下さい'),
+    postId: z.number(),
+    parentId: z.number().optional(),
+  });
+
+  const result = commentSchema.safeParse(formData);
+  if (!result.success) {
+    return NextResponse.json(
+      { success: false, errors: result.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  const { author, content, postId, parentId } = result.data;
+
+  const newComment = await prisma.comment.create({
+    data: {
+      author,
+      content,
+      postId,
+      parentId,
+      authorEmail: session?.user?.email ?? 'anonymous@unknown.com',
+    },
+  });
+
+  return NextResponse.json({ success: true, comment: newComment });
+}

--- a/src/components/form/EditForm.tsx
+++ b/src/components/form/EditForm.tsx
@@ -10,9 +10,25 @@ import PostPreview from '../post/PostPreview';
 import TagInput from '../tag/TagInput';
 import MarkdownEditor from '../post/MarkdownEditor';
 import CoverImageUpload from '../upload/CoverImageUpload';
+import { useFormStatus } from 'react-dom';
 
 type PostProps = {
   post: Post;
+};
+
+const SubmitButton = () => {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      type="submit"
+      disabled={pending}
+      size="lg"
+      className="mt-4 hover:bg-gray-400 cursor-pointer"
+    >
+      投稿する
+    </Button>
+  );
 };
 
 const EditForm = ({ post }: PostProps) => {
@@ -61,13 +77,7 @@ const EditForm = ({ post }: PostProps) => {
               published={published}
               onPublished={setPublished}
             />
-            <Button
-              type="submit"
-              size="lg"
-              className="w-full mt-4 hover:bg-gray-400 cursor-pointer"
-            >
-              投稿する
-            </Button>
+            <SubmitButton />
             <input
               type="hidden"
               name="published"

--- a/src/components/form/PostCreateForm.tsx
+++ b/src/components/form/PostCreateForm.tsx
@@ -10,6 +10,7 @@ import PostPreview from '../post/PostPreview';
 import TagInput from '../tag/TagInput';
 import CoverImageUpload from '../upload/CoverImageUpload';
 import MarkdownEditor from '../post/MarkdownEditor';
+import { useFormStatus } from 'react-dom';
 
 type Prop = {
   popularTags: {
@@ -19,6 +20,21 @@ type Prop = {
       id: number;
     }[];
   }[];
+};
+
+const SubmitButton = () => {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      type="submit"
+      disabled={pending}
+      size="lg"
+      className="mt-4 hover:bg-gray-400 cursor-pointer"
+    >
+      投稿する
+    </Button>
+  );
 };
 
 const PostCreateForm = ({ popularTags }: Prop) => {
@@ -99,13 +115,7 @@ const PostCreateForm = ({ popularTags }: Prop) => {
               published={published}
               onPublished={setPublished}
             />
-            <Button
-              type="submit"
-              size="lg"
-              className="mt-4 hover:bg-gray-400 cursor-pointer"
-            >
-              投稿する
-            </Button>
+            <SubmitButton />
             <input
               type="hidden"
               name="published"


### PR DESCRIPTION
## Summary

This pull request removes the use of `useActionState` from the comment submission feature and replaces it with a client-side `fetch` implementation.

---

## Details

- Removed `useActionState` from `PostDetail.tsx`
- Replaced with manual `fetch` request to `/api/comments`
- Added `useState` to manage:
  - Loading state (`isLoading`)
  - Error handling (`setErrors`)
- Maintained validation logic using Zod on the server
- Adjusted UI to reset form and state after successful submission

---

## Reason for Change

Using `fetch` instead of `useActionState` provides more flexibility and clearer control over the form behavior, especially for:

- Custom error handling
- Form reset logic
- Managing loading state visually

This approach is also more consistent with how other parts of the app handle requests.
